### PR TITLE
docs: add contributor CLAUDE.md guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,27 @@ data/
 .env.local
 *.log
 *.db
+
+# ── GSD baseline (auto-generated) ──
+.gsd
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+*.code-workspace
+.env.*
+!.env.example
+.next/
+build/
+__pycache__/
+*.pyc
+.venv/
+venv/
+target/
+vendor/
+coverage/
+.cache/
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,96 +1,275 @@
-# Drizby Project Guidelines
+# Drizby — Contributor Guide
 
-## Overview
+## What is Drizby?
 
-Drizby is a full-featured BI platform built on [drizzle-cube](https://drizzle.cube). It provides dashboards, agentic AI notebooks, a visual analysis builder, a schema/cube editor, and multi-connection database management — all powered by a semantic layer.
+Drizby is an open-source BI platform powered by [drizzle-cube](https://drizzle.cube). It provides dashboards, agentic AI notebooks, a visual analysis builder, a schema/cube editor, and multi-connection database management — all through a semantic layer that compiles Drizzle ORM schemas into analytics cubes.
+
+**Status:** Under active development. Production deployable via Docker.
+
+---
 
 ## Tech Stack
 
-- **Backend:** Hono (TypeScript), Drizzle ORM, SQLite (internal DB)
-- **Frontend:** React 18, React Router, TanStack Query, Recharts, Tailwind CSS, Monaco Editor
-- **Semantic Layer:** drizzle-cube — compiles Drizzle schemas into analytics cubes
-- **AI:** Anthropic Claude, OpenAI, Google Gemini (configurable)
-- **Auth:** Session-based with Google OAuth, CASL role-based permissions
+| Layer | Technology |
+|---|---|
+| Backend | Hono (TypeScript), Drizzle ORM |
+| Frontend | React 18, React Router, TanStack Query, Recharts, Tailwind CSS |
+| Code Editor | Monaco Editor |
+| Dashboard Grid | react-grid-layout |
+| Semantic Layer | drizzle-cube |
+| Internal DB | SQLite (better-sqlite3) |
+| User DBs | PostgreSQL, SQLite |
+| AI Providers | Anthropic Claude, OpenAI, Google Gemini |
+| Auth | Sessions, Google OAuth (Arctic), CASL permissions |
+| Tests | Vitest |
+| Linter | Biome |
+
+---
 
 ## Project Structure
 
 ```
-app.ts                  # Hono app setup, route mounting, static serving
+app.ts                   # Hono app: route mounting, middleware, static serving
+schema.ts                # Drizzle schema for the internal SQLite app DB
 src/
-  index.ts              # Server entry point (port 3461)
-  routes/               # API route handlers
-    auth.ts             # Login, register, setup, OAuth, sessions
-    connections.ts      # Database connection CRUD + testing
-    schema-files.ts     # Drizzle schema editing, introspection, AI cube gen
-    cube-definitions.ts # Cube CRUD, compilation, registration
-    analytics-pages.ts  # Dashboard CRUD, thumbnails, config
-    notebooks.ts        # Agentic notebook CRUD
-    users.ts            # User management (admin)
-    settings.ts         # AI provider config, factory reset
-    editor-types.ts     # .d.ts files for Monaco autocomplete
+  index.ts               # Entry point — starts server on port 3461
+  routes/                # API handlers (one file per domain)
+    auth.ts              # Login, register, setup, magic link
+    oauth.ts             # OAuth callback handler
+    connections.ts       # Database connection CRUD + test endpoint
+    schema-files.ts      # Drizzle schema editing, introspection, AI cube gen (SSE)
+    cube-definitions.ts  # Cube CRUD, compilation, registration with semantic layer
+    analytics-pages.ts   # Dashboard CRUD, thumbnails, per-dashboard config
+    notebooks.ts         # Agentic notebook CRUD
+    dashboards.ts        # Dashboard layout persistence
+    ai-routes.ts         # AI streaming routes
+    users.ts             # User management (admin only)
+    settings.ts          # AI provider config, factory reset
+    groups.ts            # Group management
+    editor-types.ts      # Serves .d.ts files for Monaco autocomplete
+    seed-demo.ts         # Demo seeding endpoint
   services/
-    connection-manager.ts  # Per-connection Drizzle + SemanticLayerCompiler instances
-    cube-compiler.ts       # TypeScript compilation of schemas and cubes
-    ai-settings.ts         # AI provider config reader
-  auth/                 # Session, password, OAuth, middleware
-  permissions/          # CASL role-based access control
-  db/                   # Database connection and helpers
-schema.ts               # Drizzle schema for internal SQLite DB
+    connection-manager.ts   # Manages per-connection Drizzle + SemanticLayerCompiler instances
+    cube-compiler.ts        # TypeScript compilation of schemas and cube definitions
+    ai-settings.ts          # Reads AI provider configuration
+    auto-setup.ts           # First-run setup logic
+    connection-masking.ts   # Masks sensitive credentials in API responses
+    driver-factory.ts       # Creates DB driver instances per connection type
+    email.ts                # Email delivery
+    oauth-settings.ts       # OAuth provider config
+    provider-registry.ts    # Manages registered semantic layer providers
+    typecheck-worker.ts     # Background worker for schema type-checking
+  auth/                  # Session, password, OAuth, encryption, middleware
+  permissions/           # CASL ability definitions per role
+  db/                    # Internal DB connection
 client/
   src/
-    pages/              # React page components
-    components/         # Shared UI (Modal, Layout, AuthGuard, etc.)
-    hooks/              # useConnections, useConfirm, usePrompt, etc.
-    contexts/           # AuthContext
-    theme/              # CSS variables, theming
+    pages/               # React page components (one per route)
+    components/          # Shared UI components
+    hooks/               # Custom React hooks
+    contexts/            # AuthContext
+    theme/               # CSS variables and theming
+drizzle/                 # Migration files (auto-generated, committed)
+tests/                   # Integration tests
+  helpers/               # test-db.ts (in-memory SQLite), test-app.ts (route mounting)
+scripts/                 # build-server.ts, migrate.ts, seed.ts
 ```
 
-## Running
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- npm
+
+### First-time setup
 
 ```bash
-npm run dev          # Start client (3460) + server (3461) with hot reload
-npm run setup        # Generate migrations, run them, seed demo data
-npm run build:client # TypeScript check + Vite production build
+git clone https://github.com/cliftonc/drizby.git
+cd drizby
+npm install --legacy-peer-deps
+npm run setup          # generate migrations → apply them → seed demo data
+npm run dev            # client on :3460, server on :3461
 ```
+
+Open [http://localhost:3460](http://localhost:3460). The setup wizard runs on first boot.
+
+### Docker (production)
+
+```bash
+docker run -p 3461:3461 -v drizby-data:/app/data ghcr.io/cliftonc/drizby:main
+```
+
+---
+
+## Development Commands
+
+```bash
+npm run dev            # Start client (:3460) + server (:3461) with hot reload
+npm run dev:server     # Server only (tsx watch)
+npm run dev:client     # Client only (Vite HMR)
+
+npm run db:generate    # Generate a new migration from schema.ts changes
+npm run db:migrate     # Apply pending migrations
+npm run db:seed        # Seed demo data
+
+npm run build          # Full production build (client + server)
+npm run build:client   # TypeScript check + Vite build
+npm run build:server   # esbuild server bundle
+
+npm run lint           # Biome lint + format check
+npm run lint:fix       # Biome lint + format with auto-fix
+npm run typecheck      # tsc --noEmit
+npm test               # Vitest integration tests
+```
+
+---
+
+## Pre-commit Checklist
+
+All three must pass before pushing. CI enforces this.
+
+```bash
+npm run lint           # Biome lint + format
+npm run typecheck      # TypeScript type check
+npm test               # Vitest tests
+```
+
+---
 
 ## Database Migrations
 
-- **Never use `drizzle-kit push`** — it applies changes directly to the DB without creating migration files, causing the migration runner to fail on duplicate changes. Always use `drizzle-kit generate` to create migration files, then let the app's `migrate()` call apply them on startup.
-- Migration files live in `drizzle/` and are tracked in `drizzle/meta/_journal.json`.
+**Never use `drizzle-kit push`.** It applies changes directly to the DB without creating migration files — the migration runner will then fail with duplicate-change errors on the next startup.
+
+The correct workflow:
+
+1. Edit `schema.ts`
+2. `npm run db:generate` — creates a new file in `drizzle/`
+3. Commit the generated migration alongside the schema change
+4. Migrations run automatically on app startup via `migrate()`
+
+Migration files live in `drizzle/` and are tracked in `drizzle/meta/_journal.json`.
+
+---
+
+## Architecture Notes
+
+### Multi-connection semantic layer
+
+Each database connection gets its own Drizzle instance and `SemanticLayerCompiler`. When a cube is compiled and registered, it lives under that connection's provider. `connection-manager.ts` owns this lifecycle.
+
+### Cube query path
+
+All `/cubejs-api/*` routes proxy through drizzle-cube's semantic layer, which translates cube queries to SQL with security context enforcement. The semantic layer is the only thing that touches user databases.
+
+### Auth flow
+
+`authMiddleware` (in `src/auth/middleware.ts`) supports three modes in order:
+1. Dev API key (`Bearer dc-bi-dev-key` in non-production)
+2. OAuth bearer tokens (opaque or JWT-wrapped)
+3. Session cookies
+
+### Permissions
+
+CASL abilities are defined per role in `src/permissions/abilities.ts`. The three roles are `admin`, `member`, and `user` (pending approval). Abilities are set on the Hono context by `authMiddleware` and consumed via `c.get('ability')` in route handlers.
+
+### Organisation scoping
+
+All data is scoped by `organisationId`. Currently single-tenant (hardcoded to 1), but the column exists on every table in preparation for multi-tenancy.
+
+### Soft deletes
+
+Dashboards and notebooks use an `isActive` flag rather than hard deletes.
+
+### Demo seeding
+
+On first boot with no connections configured, `auto-setup.ts` creates a demo SQLite database with sample employee/productivity data, cube definitions, and a pre-built dashboard.
+
+---
 
 ## UI Rules
 
-- **Never use browser `alert()`, `confirm()`, or `prompt()` dialogs.** Use the generic `Modal`, `ConfirmModal`, and `PromptModal` components from `client/src/components/Modal.tsx`, or the `useConfirm` / `usePrompt` hooks from `client/src/hooks/` for imperative flows.
+- **Never use `alert()`, `confirm()`, or `prompt()`** — they block the main thread and look terrible. Use:
+  - `<Modal>`, `<ConfirmModal>`, `<PromptModal>` from `client/src/components/Modal.tsx`
+  - `useConfirm()` / `usePrompt()` hooks from `client/src/hooks/` for imperative flows
+- CSS variables and theming live in `client/src/theme/`. Dark/light mode is toggled via `ThemeToggle` and stored in `localStorage`.
 
-## Dev API Access
+---
 
-In dev mode (`NODE_ENV !== 'production'`), all API endpoints accept a Bearer token for auth bypass:
+## Testing
+
+Tests are integration tests, not unit tests. Each test creates a fresh in-memory SQLite database with the full migration history applied.
+
+```ts
+// tests/helpers/test-db.ts
+const { db } = createTestDb()         // in-memory SQLite, all migrations applied
+
+// tests/helpers/test-app.ts
+const app = mountRoute(routeApp, { db, user: adminUser })  // inject auth + db into Hono app
+```
+
+To add tests for a route:
+1. Import the route handler
+2. `createTestDb()` + seed any required fixtures
+3. `mountRoute()` to build a testable app
+4. Use `app.request()` directly (no HTTP server needed)
+
+---
+
+## Dev API Bypass
+
+In dev mode (`NODE_ENV !== 'production'`), all API routes accept a bearer token for auth bypass:
 
 ```
 Authorization: Bearer dc-bi-dev-key
 ```
 
-This works on both `/api/*` and `/cubejs-api/*` routes. The key defaults to `dc-bi-dev-key` and can be overridden via `DEV_API_KEY` env var. Authenticates as admin user (id: 1).
-
-Example: `curl -H 'Authorization: Bearer dc-bi-dev-key' http://localhost:3461/cubejs-api/v1/meta`
-
-## Pre-commit Checks
-
-**Always run these before committing:**
+Works on both `/api/*` and `/cubejs-api/*`. Authenticates as admin user (id: 1). Override the key with `DEV_API_KEY` env var.
 
 ```bash
-npm run lint          # Biome lint + format check
-npx tsc --noEmit      # TypeScript type check
-npm test              # Vitest tests
+curl -H 'Authorization: Bearer dc-bi-dev-key' http://localhost:3461/api/connections
+curl -H 'Authorization: Bearer dc-bi-dev-key' http://localhost:3461/cubejs-api/v1/meta
 ```
 
-All three must pass — CI will reject the push otherwise.
+---
 
-## Key Architecture Notes
+## Adding a New Feature
 
-- **Multi-connection:** Each database connection gets its own Drizzle instance and SemanticLayerCompiler. Cubes are registered per connection.
-- **Semantic layer:** drizzle-cube sits between queries and the database. It translates cube queries to SQL with security context enforcement.
-- **Cube API:** All `/cubejs-api/*` routes proxy through drizzle-cube's semantic layer.
-- **Soft deletes:** Dashboards and notebooks use `isActive` flag.
-- **Organisation scoping:** All data is scoped by `organisationId` (currently single-tenant, hardcoded to 1).
-- **Demo seeding:** On first startup with no connections, a demo SQLite database with sample data, cubes, and a dashboard is auto-created.
+### Backend route
+
+1. Create or extend a file in `src/routes/`
+2. Register it in `app.ts`
+3. Add CASL ability checks via `c.get('ability').can(action, subject)` — see existing routes for the pattern
+4. Write a test in `tests/` using `createTestDb` + `mountRoute`
+
+### Frontend page
+
+1. Create a page component in `client/src/pages/`
+2. Add a route in `client/src/App.tsx` (or wherever routes are declared)
+3. Wrap with `<AuthGuard>` if auth is required
+4. Use TanStack Query for data fetching — see existing pages for the pattern
+
+### Schema change
+
+1. Edit `schema.ts`
+2. `npm run db:generate`
+3. Commit the generated migration file
+4. Update any affected routes, services, and tests
+
+---
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NODE_ENV` | — | `production` disables dev API key bypass |
+| `DEV_API_KEY` | `dc-bi-dev-key` | Bearer token for dev auth bypass |
+| `PORT` | `3461` | Server port |
+| `DATABASE_URL` | `./data/drizby.db` | Path to internal SQLite DB |
+| `SESSION_SECRET` | — | Required in production for cookie signing |
+| `GOOGLE_CLIENT_ID` | — | Optional: Google OAuth |
+| `GOOGLE_CLIENT_SECRET` | — | Optional: Google OAuth |
+
+AI provider keys are configured at runtime through the Settings UI and stored in the database.

--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -1,0 +1,86 @@
+# client/ — Frontend Guide
+
+The frontend is React 18 with React Router, TanStack Query, Tailwind CSS, and Recharts. Dev server runs on port 3460 and proxies `/api/*` + `/cubejs-api/*` to the backend on :3461.
+
+## Structure
+
+```
+client/src/
+  App.tsx               # Router setup, route definitions, AuthGuard wrapping
+  main.tsx              # React entry point
+  pages/                # One component per route — named *Page.tsx
+  components/           # Shared, reusable UI components
+  hooks/                # Custom hooks (data fetching, UI utilities)
+  contexts/             # AuthContext — current user, login/logout
+  theme/                # CSS custom properties, dark/light mode
+```
+
+## Adding a Page
+
+1. Create `client/src/pages/MyFeaturePage.tsx`
+2. Add a route in `App.tsx`:
+   ```tsx
+   <Route path="/my-feature" element={<AuthGuard><MyFeaturePage /></AuthGuard>} />
+   ```
+3. Add a nav link if it belongs in the sidebar (see `Layout.tsx`)
+
+## Data Fetching
+
+Use TanStack Query. See existing pages for the pattern:
+
+```tsx
+const { data, isLoading, error } = useQuery({
+  queryKey: ['my-resource'],
+  queryFn: () => fetch('/api/my-resource').then(r => r.json()),
+})
+
+const mutation = useMutation({
+  mutationFn: (body) => fetch('/api/my-resource', { method: 'POST', body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } }).then(r => r.json()),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['my-resource'] }),
+})
+```
+
+## Modal / Dialog Rules
+
+**Never use `alert()`, `confirm()`, or `prompt()`.**
+
+Use the provided components:
+
+```tsx
+// Declarative
+import { ConfirmModal, PromptModal } from '../components/Modal'
+<ConfirmModal open={open} onConfirm={handleConfirm} onCancel={() => setOpen(false)} message="Are you sure?" />
+
+// Imperative (from hooks)
+import { useConfirm } from '../hooks/useConfirm'
+import { usePrompt } from '../hooks/usePrompt'
+
+const confirm = useConfirm()
+const confirmed = await confirm('Delete this dashboard?')
+
+const prompt = usePrompt()
+const name = await prompt('Enter a name', { placeholder: 'Dashboard name' })
+```
+
+## Auth
+
+Use `AuthContext` to get the current user:
+
+```tsx
+import { useAuth } from '../contexts/AuthContext'
+
+const { user, isLoading } = useAuth()
+```
+
+Role-based rendering — check `user.role === 'admin'` for admin-only UI elements. Route-level protection uses `<AuthGuard>`.
+
+## Theming
+
+CSS variables are declared in `client/src/theme/`. Dark/light mode toggled via `<ThemeToggle>` and persisted in `localStorage`. Prefer CSS variables over hardcoded colors.
+
+## Conventions
+
+- Pages handle routing and data — keep them thin by extracting logic into hooks
+- Shared state goes in TanStack Query cache, not React context (except auth)
+- Component files match their export name: `ConnectionForm.tsx` exports `ConnectionForm`
+- No `alert()`, `confirm()`, or `prompt()` — see modal rules above

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,95 @@
+# src/ — Backend Guide
+
+The backend is a [Hono](https://hono.dev) app in TypeScript. All API routes are under `/api/*`; cube/semantic layer routes are under `/cubejs-api/*`.
+
+## Structure
+
+```
+src/
+  index.ts              # Entry point — creates DB, runs migrations, starts server on :3461
+  routes/               # API handlers
+  services/             # Business logic, no HTTP context
+  auth/                 # Session, password, OAuth, middleware
+  permissions/          # CASL abilities
+  db/                   # Internal DB connection (better-sqlite3 + Drizzle ORM)
+```
+
+## Writing a Route
+
+Routes use Hono. Every route handler gets `db`, `auth`, and `ability` from context:
+
+```ts
+import { Hono } from 'hono'
+import { guardAbility } from '../permissions/guard'
+
+const app = new Hono<{ Variables: { db: any; auth: any; ability: any } }>()
+
+app.get('/', async (c) => {
+  const db = c.get('db')
+  const ability = c.get('ability')
+  guardAbility(ability, 'read', 'Connection')   // throws 403 if not allowed
+  // ...
+  return c.json({ data })
+})
+
+export default app
+```
+
+Register the route in `app.ts`:
+
+```ts
+app.route('/api/my-thing', myThingRoute)
+```
+
+## Auth Middleware
+
+`src/auth/middleware.ts` — runs on every `/api/*` and `/cubejs-api/*` request. Sets `auth` and `ability` on context. Three auth paths:
+
+1. Dev bearer token (`Bearer dc-bi-dev-key`) — skipped in production
+2. OAuth bearer token (opaque or JWT-wrapped)
+3. Session cookie
+
+## Permissions
+
+Roles: `admin`, `member`, `user` (pending). Abilities defined in `src/permissions/abilities.ts`.
+
+```ts
+// Check in a route:
+const ability = c.get('ability')
+if (!ability.can('update', 'Dashboard')) return c.json({ error: 'Forbidden' }, 403)
+
+// Or use the guard helper (throws 403):
+guardAbility(ability, 'update', 'Dashboard')
+```
+
+Members cannot manage connections, schemas, cubes, or users — those are admin-only.
+
+## Services
+
+Services are plain TypeScript modules — no Hono context. They receive `db` and typed parameters.
+
+Key services:
+
+- **`connection-manager.ts`** — `getConnectionInstance(connectionId)` returns a `{ db, compiler }` pair. Each connection gets its own Drizzle instance and SemanticLayerCompiler.
+- **`cube-compiler.ts`** — compiles TypeScript schema/cube strings; used by the schema editor.
+- **`connection-masking.ts`** — strips sensitive fields (passwords, secret keys) from connection objects before returning to clients.
+- **`driver-factory.ts`** — creates DB driver instances for PostgreSQL and SQLite connections.
+
+## Error Handling
+
+Return structured JSON errors:
+
+```ts
+return c.json({ error: 'Not found' }, 404)
+return c.json({ error: 'Validation failed', details: [...] }, 422)
+```
+
+Log unexpected errors with context — don't swallow them silently.
+
+## Organisation Scoping
+
+All queries must scope by `organisationId`. Currently hardcoded to 1 — but the column is on every table and every query should filter on it for future multi-tenancy readiness.
+
+```ts
+.where(and(eq(table.organisationId, 1), eq(table.id, id)))
+```

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,93 @@
+# tests/ — Testing Guide
+
+Integration tests using [Vitest](https://vitest.dev). Tests run against a real SQLite DB with the full migration history applied — no mocks of the DB layer.
+
+## Run Tests
+
+```bash
+npm test               # All tests
+npx vitest run tests/my-test.ts   # Single file
+npx vitest watch       # Watch mode
+```
+
+## Helpers
+
+### `helpers/test-db.ts`
+
+Creates a fresh in-memory SQLite database with all migrations applied:
+
+```ts
+import { createTestDb, seedAdminUser, seedMemberUser } from './helpers/test-db'
+
+const { db } = createTestDb()
+const admin = await seedAdminUser(db)
+const member = await seedMemberUser(db)
+```
+
+Each test file should call `createTestDb()` in a `beforeEach` so tests are fully isolated.
+
+### `helpers/test-app.ts`
+
+Mounts a Hono route handler with injected `db`, `auth`, and `ability` context — no real HTTP server:
+
+```ts
+import { mountRoute, jsonRequest } from './helpers/test-app'
+import myRoute from '../src/routes/my-route'
+
+const app = mountRoute(myRoute, { db, user: admin })
+
+// Make requests directly
+const res = await jsonRequest(app, 'POST', '/test/resource', { name: 'Test' })
+expect(res.status).toBe(201)
+const body = await res.json()
+```
+
+The `prefix` argument (default `/test`) is the base path within the test app.
+
+## Writing a New Test
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createTestDb, seedAdminUser } from './helpers/test-db'
+import { mountRoute, jsonRequest } from './helpers/test-app'
+import myRoute from '../src/routes/my-route'
+
+describe('my-route', () => {
+  let db: any
+  let admin: any
+  let app: any
+
+  beforeEach(async () => {
+    ({ db } = createTestDb())
+    admin = await seedAdminUser(db)
+    app = mountRoute(myRoute, { db, user: admin })
+  })
+
+  it('creates a resource', async () => {
+    const res = await jsonRequest(app, 'POST', '/test/', { name: 'Foo' })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.name).toBe('Foo')
+  })
+
+  it('returns 403 for members', async () => {
+    const { db: db2 } = createTestDb()
+    const member = await seedMemberUser(db2)
+    const memberApp = mountRoute(myRoute, { db: db2, user: member })
+    const res = await jsonRequest(memberApp, 'DELETE', '/test/1')
+    expect(res.status).toBe(403)
+  })
+})
+```
+
+## What to Test
+
+- Happy path CRUD for each route
+- Permission enforcement (admin vs member vs unauthenticated)
+- Edge cases: not found, validation errors, duplicate records
+- Any service-level logic with non-trivial branching (`cube-compiler.test.ts` is a good example)
+
+## What Not to Test
+
+- Framework behaviour (Hono routing, Drizzle SQL generation)
+- UI rendering — the frontend has no test suite yet; rely on TypeScript and manual testing


### PR DESCRIPTION
## Summary

Adds structured contributor documentation as `CLAUDE.md` files at the repo root and in key sub-directories. These files are picked up automatically by Claude Code and other AI coding tools to provide context, but they're equally useful as human contributor guides.

## Changes

- **`CLAUDE.md`** (root) — expanded from the original: full scripts table, complete project structure, testing patterns, feature addition walkthrough, environment variables table
- **`src/CLAUDE.md`** — backend guide: Hono route conventions, auth middleware internals, CASL permission patterns, service responsibilities, error handling, org scoping
- **`client/CLAUDE.md`** — frontend guide: page creation, TanStack Query patterns, modal/dialog rules, auth context, theming conventions
- **`tests/CLAUDE.md`** — testing guide: helper API docs (`createTestDb`, `mountRoute`), full worked example, scope guidance
- **`.gitignore`** — adds `.gsd` and common IDE/OS/build artifacts

## Why

Makes it easy for new contributors (human or AI) to understand where things live, how to add features, and what the guardrails are — without having to read the source first.