### PR TITLE
fix: make type-check worker loading robust across Node versions

### DIFF
--- a/src/services/cube-compiler.ts
+++ b/src/services/cube-compiler.ts
@@ -49,6 +49,41 @@ const WORKER_EXT = CURRENT_FILE.endsWith('.ts') ? '.ts' : '.js'
 const WORKER_PATH = join(CURRENT_DIR, `typecheck-worker${WORKER_EXT}`)
 
 /**
+ * Build execArgv for the worker thread.
+ * When the worker is a .ts file, we need a TypeScript loader registered.
+ * Node ≥ 22.6 handles .ts natively (--experimental-strip-types, on by default in v24+).
+ * Older Node versions need tsx. We check:
+ *   1. Parent already has tsx/ts-node flags → propagate them
+ *   2. Node has native TS stripping → no extra flags needed
+ *   3. Otherwise → add --import tsx so the worker can load .ts
+ */
+function buildWorkerExecArgv(): string[] {
+  if (WORKER_EXT === '.js') return []
+
+  const parentArgv = process.execArgv.filter(arg => !arg.startsWith('-e') && arg !== '--')
+
+  // Parent already has tsx or ts-node loader registered
+  if (parentArgv.some(arg => arg.includes('tsx') || arg.includes('ts-node'))) {
+    return parentArgv
+  }
+
+  // Node ≥ 22.6 has --experimental-strip-types (on by default in v24+)
+  const [major, minor] = process.versions.node.split('.').map(Number)
+  if (major > 22 || (major === 22 && minor >= 6)) {
+    return parentArgv
+  }
+
+  // Older Node — try to add tsx as a loader
+  try {
+    esmRequire.resolve('tsx')
+    return [...parentArgv, '--import', 'tsx']
+  } catch {
+    // tsx not installed — fall back to parent argv and hope for the best
+    return parentArgv
+  }
+}
+
+/**
  * Run type-checking in a worker thread so it doesn't block the event loop.
  * Returns only errors (serializable). Execution happens on the main thread afterward.
  */
@@ -59,8 +94,7 @@ function typeCheckInWorker(
   return new Promise(resolve => {
     const worker = new Worker(WORKER_PATH, {
       workerData: { sourceCode, virtualFiles, projectRoot: PROJECT_ROOT },
-      // Pass parent's execArgv so tsx/ts-node loaders work in the worker
-      execArgv: process.execArgv,
+      execArgv: buildWorkerExecArgv(),
     })
     worker.on('message', (msg: { errors: CompileError[] }) => {
       resolve(msg.errors)

--- a/tests/cube-compiler.test.ts
+++ b/tests/cube-compiler.test.ts
@@ -116,6 +116,34 @@ describe('cube-compiler', () => {
     })
   })
 
+  // ─── Worker startup regression ───────────────────────────────
+
+  describe('worker startup', () => {
+    it('type-check worker completes without startup errors', async () => {
+      // Exercises the full worker path (spawn → type-check → message back).
+      // This is the scenario that fails when the .ts worker can't be loaded.
+      const result = await compileSchema(`
+        import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+        export const t = sqliteTable('t', { id: text('id') })
+      `)
+      expect(result.errors).toHaveLength(0)
+      // Ensure we actually got exports (worker ran, not just a fallback)
+      expect(result.exports.t).toBeDefined()
+    })
+
+    it('worker errors are reported as structured CompileError[]', async () => {
+      // Invalid TS that should trigger a type-check error from the worker
+      const result = await compileSchema(`
+        import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+        const x: number = 'not a number'
+        export const t = sqliteTable('t', { id: text('id') })
+      `)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0]).toHaveProperty('message')
+      expect(typeof result.errors[0].message).toBe('string')
+    })
+  })
+
   // ─── Sandbox isolation (fast, no type-checking) ───────────────
 
   describe('sandbox blocks dangerous globals', () => {


### PR DESCRIPTION
## Summary

Fixes #14 — the cube-compiler's type-check worker failed with `Unknown file extension ".ts"` in environments where the parent process didn't have tsx/ts-node loaders registered (e.g. under Vitest, or on Node < 22.6).

- **New `buildWorkerExecArgv()`** replaces blind `process.execArgv` propagation with smart detection:
  1. Propagates parent flags if tsx/ts-node already registered
  2. No-ops on Node ≥ 22.6 (native `--experimental-strip-types`)
  3. Explicitly adds `--import tsx` on older Node when tsx is installed
- **2 regression tests** for worker startup success and structured error reporting

## Test plan

- [x] All 26 cube-compiler tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Typecheck clean (`npm run typecheck`)
- [ ] Verify on Node 20/22 environment if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)